### PR TITLE
add backend host

### DIFF
--- a/django/api/settings.py
+++ b/django/api/settings.py
@@ -30,11 +30,12 @@ CORS_ORIGIN_WHITELIST = [
     os.getenv('CORS_ORIGIN_WHITELIST', 'http://localhost:3000')
 ]
 
-CSRF_TRUSTED_ORIGINS = [
-    os.getenv('CORS_ORIGIN_WHITELIST', 'http://localhost:3000')
-]
-
 ALLOWED_HOSTS = [os.getenv('ALLOWED_HOSTS', '*')]
+
+CSRF_TRUSTED_ORIGINS = [
+    os.getenv('CORS_ORIGIN_WHITELIST', 'http://localhost:3000'),
+    os.getenv('ALLOWED_HOSTS')
+]
 
 # Application definition
 INSTALLED_APPS = [


### PR DESCRIPTION
Openshift

Reason given for failure:

    Origin checking failed - https://itvr-backend-dev-11.apps.silver.devops.gov.bc.ca does not match any trusted origins.