### PR TITLE
minor fix - tax year note on eligibility page

### DIFF
--- a/frontend/src/components/Eligibility/EligibilityPage.js
+++ b/frontend/src/components/Eligibility/EligibilityPage.js
@@ -8,6 +8,9 @@ import Box from '@mui/material/Box';
 const EligibilityPage = (props) => {
   const { taxYear, questions, setQuestions, handleCheckboxChange, eligible } =
     props;
+  const date = new Date();
+  const twoYearsAgo = date.getFullYear() - 2;
+  const lastYear = date.getFullYear() - 1;
   const { keycloak } = useKeycloak();
   const title = <h3>What you will need to complete this application</h3>;
   const applicationText = (
@@ -79,9 +82,9 @@ const EligibilityPage = (props) => {
       />
       <div className="asterisk-text">
         <p>
-          * UP Until June 30 your {taxYear} notice of assessment (NOA) will be
-          used to determine your rebate amount. On July 1 it will change to use
-          your {taxYear} NOA.
+          * UP Until June 30 your {twoYearsAgo} notice of assessment (NOA) will
+          be used to determine your rebate amount. On July 1 it will change to
+          use your {lastYear} NOA.
         </p>
       </div>
       <div>


### PR DESCRIPTION
-fixes note about what year gets used for taxYear-- last year and two years ago instead of using the taxYear variable

![image](https://user-images.githubusercontent.com/44536222/164300033-366636d8-9099-4fb0-8183-7e97a1618d81.png)

![image](https://user-images.githubusercontent.com/44536222/164299889-3e1c5e19-5f42-4187-ad3e-c6fd850099f8.png)
