### PR TITLE
configure orm cache

### DIFF
--- a/django/api/settings.py
+++ b/django/api/settings.py
@@ -196,3 +196,10 @@ Q_CLUSTER = {
     "bulk": 10,
     "orm": "default",
 }
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "itvr_cache_table",
+    }
+}


### PR DESCRIPTION
@kuanfandevops this doesn't generate a migration, so the management command below will need to be run in an openshift deploy script it seems.

[Creating the cache table](https://docs.djangoproject.com/en/4.0/topics/cache/#creating-the-cache-table)
Before using the database cache, you must create the cache table with this command:

```sh
python manage.py createcachetable
```