### PR TITLE
Itvr291-and-288--restrict-application-routes

### DIFF
--- a/django/api/serializers/application_form.py
+++ b/django/api/serializers/application_form.py
@@ -72,3 +72,13 @@ class ApplicationFormSerializer(ModelSerializer):
     class Meta:
         model = GoElectricRebateApplication
         fields = "__all__"
+
+
+class ApplicationFormSpouseSerializer(ModelSerializer):
+    class Meta:
+        model = GoElectricRebateApplication
+        fields = [
+            "address",
+            "city",
+            "postal_code",
+        ]

--- a/django/api/serializers/household_member.py
+++ b/django/api/serializers/household_member.py
@@ -1,3 +1,4 @@
+from api.serializers.application_form import ApplicationFormSpouseSerializer
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from api.models.household_member import HouseholdMember
 from api.models.go_electric_rebate_application import GoElectricRebateApplication
@@ -39,12 +40,13 @@ class HouseholdMemberApplicationCreateSerializer(ModelSerializer):
 
 
 class HouseholdMemberApplicationGetSerializer(ModelSerializer):
-    application_id = SerializerMethodField()
     sin = SerializerMethodField()
     address = SerializerMethodField()
     city = SerializerMethodField()
     postal_code = SerializerMethodField()
     tax_year = SerializerMethodField()
+    application_type = SerializerMethodField()
+    status = SerializerMethodField()
 
     def get_address(self, obj):
         return obj.application.address
@@ -61,6 +63,12 @@ class HouseholdMemberApplicationGetSerializer(ModelSerializer):
     def get_application_id(self, obj):
         return obj.application.id
 
+    def get_application_type(self, obj):
+        return obj.application.application_type
+
+    def get_status(self, obj):
+        return obj.application.status
+
     def get_sin(self, obj):
         return "******" + str(obj.sin)[-3:]
 
@@ -68,6 +76,8 @@ class HouseholdMemberApplicationGetSerializer(ModelSerializer):
         model = HouseholdMember
         fields = (
             "application_id",
+            "application_type",
+            "status",
             "address",
             "city",
             "postal_code",

--- a/django/api/serializers/household_member.py
+++ b/django/api/serializers/household_member.py
@@ -1,7 +1,6 @@
 from api.serializers.application_form import ApplicationFormSpouseSerializer
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
 from api.models.household_member import HouseholdMember
-from api.models.go_electric_rebate_application import GoElectricRebateApplication
 from rest_framework.parsers import FormParser, MultiPartParser
 
 
@@ -40,6 +39,7 @@ class HouseholdMemberApplicationCreateSerializer(ModelSerializer):
 
 
 class HouseholdMemberApplicationGetSerializer(ModelSerializer):
+    application_id = SerializerMethodField()
     sin = SerializerMethodField()
     address = SerializerMethodField()
     city = SerializerMethodField()

--- a/django/api/viewsets/application_form.py
+++ b/django/api/viewsets/application_form.py
@@ -1,18 +1,18 @@
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import GenericViewSet
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin
 
 from api.serializers.application_form import (
     ApplicationFormSerializer,
     ApplicationFormCreateSerializer,
+    ApplicationFormSpouseSerializer,
 )
 from api.models.go_electric_rebate_application import GoElectricRebateApplication
-from api.models.household_member import HouseholdMember
-from api.serializers.household_member import HouseholdMemberApplicationGetSerializer
 
 
-class ApplicationFormViewset(ModelViewSet):
+class ApplicationFormViewset(GenericViewSet, CreateModelMixin, RetrieveModelMixin):
     queryset = GoElectricRebateApplication.objects.all()
     serializer_classes = {
         "default": ApplicationFormSerializer,
@@ -21,11 +21,20 @@ class ApplicationFormViewset(ModelViewSet):
 
     @action(detail=True, methods=["GET"], url_path="household")
     def household(self, request, pk=None):
-        household_member = HouseholdMember.objects.filter(application=pk)
-        serializer = HouseholdMemberApplicationGetSerializer(
-            household_member, many=True
-        )
-        return Response(serializer.data[0], status=status.HTTP_200_OK)
+        # not possible to restrict this endpoint to only the spouse because, at this point,
+        # no household_member record associated with the spouse has been created yet, and we're not storing the spouse email
+        # associated with household applications
+        application = GoElectricRebateApplication.objects.get(pk=pk)
+        serializer = ApplicationFormSpouseSerializer(application)
+        return Response(serializer.data)
+
+    def retrieve(self, request, pk=None):
+        application = GoElectricRebateApplication.objects.get(pk=pk)
+        if application.user.id == request.user.id:
+            serializer = ApplicationFormSerializer(application)
+            return Response(serializer.data)
+        response = {"message": "Forbidden"}
+        return Response(response, status=status.HTTP_403_FORBIDDEN)
 
     def get_serializer_class(self):
         if self.action in list(self.serializer_classes.keys()):

--- a/django/api/viewsets/household_member.py
+++ b/django/api/viewsets/household_member.py
@@ -1,5 +1,4 @@
 from rest_framework.viewsets import GenericViewSet
-from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin

--- a/django/api/viewsets/household_member.py
+++ b/django/api/viewsets/household_member.py
@@ -1,7 +1,8 @@
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import GenericViewSet
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.mixins import CreateModelMixin, RetrieveModelMixin
 
 from api.models.household_member import HouseholdMember
 
@@ -9,22 +10,24 @@ from api.serializers.household_member import (
     HouseholdMemberApplicationGetSerializer,
     HouseholdMemberApplicationCreateSerializer,
 )
-from api.models.go_electric_rebate_application import GoElectricRebateApplication
 
 
-class HouseholdMemberApplicationViewset(ModelViewSet):
+class HouseholdMemberApplicationViewset(
+    GenericViewSet, CreateModelMixin, RetrieveModelMixin
+):
     queryset = HouseholdMember.objects.all()
     serializer_classes = {
         "default": HouseholdMemberApplicationGetSerializer,
         "create": HouseholdMemberApplicationCreateSerializer,
     }
 
-    @action(detail=True, methods=["GET"], url_path="initiate")
-    def initiate(self, request, pk=None):
-        application = GoElectricRebateApplication.objects.get(id=pk)
-        household_member = HouseholdMember(application=application)
-        serializer = HouseholdMemberApplicationGetSerializer(household_member)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+    def retrieve(self, request, pk=None):
+        household_member = HouseholdMember.objects.get(application=pk)
+        if household_member.user.id == request.user.id:
+            serializer = HouseholdMemberApplicationGetSerializer(household_member)
+            return Response(serializer.data)
+        response = {"message": "Forbidden"}
+        return Response(response, status=status.HTTP_403_FORBIDDEN)
 
     def get_serializer_class(self):
         if self.action in list(self.serializer_classes.keys()):

--- a/frontend/src/components/ApplicationSummary.js
+++ b/frontend/src/components/ApplicationSummary.js
@@ -8,7 +8,7 @@ const ApplicationSummary = ({ id, applicationType = '' }) => {
   const axiosInstance = useAxios();
   const detailUrl =
     applicationType === 'household'
-      ? `/api/application-form/${id}/household`
+      ? `/api/spouse-application/${id}`
       : `/api/application-form/${id}`;
   const queryFn = () =>
     axiosInstance.current.get(detailUrl).then((response) => {
@@ -28,13 +28,15 @@ const ApplicationSummary = ({ id, applicationType = '' }) => {
   return (
     <Box>
       <h3>
-        {(applicationType || data.application_type) === 'household'
+        {data.application_type === 'household'
           ? 'Household Application'
           : 'Individual Application Confirmation'}
       </h3>
       <p>
-        Print this page for your records. You will also receive an email
-        confirmation at {data.email}.
+        {data.status !== 'submitted' || data.application_type !== 'household'
+          ? 'Print this page for your records. You will also receive an email confirmation at ' +
+            data.email
+          : 'Print this page for your records.'}
       </p>
       {data.status === 'household_initiated' && (
         <p>Your spouse will receive an email to complete this application.</p>

--- a/frontend/src/components/DetailsTable.js
+++ b/frontend/src/components/DetailsTable.js
@@ -67,25 +67,29 @@ const DetailsTable = ({ data }) => {
     <TableContainer component={Paper} sx={{ boxShadow: 0 }}>
       <Table sx={{ minWidth: 650, border: 0 }} aria-label="simple table">
         <TableBody>
-          {rows.map((row) => (
-            <TableRow key={row.name} sx={{ border: 0 }}>
-              <TableCell
-                component="th"
-                scope="row"
-                sx={{ border: 0, width: '25%' }}
-              >
-                <b>{row.name}</b>
-              </TableCell>
-              <TableCell
-                align="left"
-                sx={{ border: 0 }}
-                className="application-details-table-answer"
-                style={{ verticalAlign: 'top' }}
-              >
-                {row.answer}
-              </TableCell>
-            </TableRow>
-          ))}
+          {rows.map((row) => {
+            if (row.answer) {
+              return (
+                <TableRow key={row.name} sx={{ border: 0 }}>
+                  <TableCell
+                    component="th"
+                    scope="row"
+                    sx={{ border: 0, width: '25%' }}
+                  >
+                    <b>{row.name}</b>
+                  </TableCell>
+                  <TableCell
+                    align="left"
+                    sx={{ border: 0 }}
+                    className="application-details-table-answer"
+                    style={{ verticalAlign: 'top' }}
+                  >
+                    {row.answer}
+                  </TableCell>
+                </TableRow>
+              );
+            }
+          })}
         </TableBody>
       </Table>
     </TableContainer>

--- a/frontend/src/components/SpouseForm.js
+++ b/frontend/src/components/SpouseForm.js
@@ -47,7 +47,7 @@ const SpouseForm = ({ id, setNumberOfErrors, setErrorsExistCounter }) => {
 
   const queryFn = () =>
     axiosInstance.current
-      .get(`/api/spouse-application/${id}/initiate`)
+      .get(`/api/application-form/${id}/household`)
       .then((response) => response.data);
 
   const { data, isLoading, isError, error } = useQuery(


### PR DESCRIPTION
@naomiaro @emi-hi please review. Also, please note:

(1) The call to /api/application-form/{id}/household is being used to populate the address, city, and postal code of the application form when the spouse does their portion. This call is not restricted because, at the time of the call, no household_member record has been created yet. This should be okay because the {id} is uniquely generated and address details are not that sensitive?