### PR TITLE
Add test for name truncation

### DIFF
--- a/django/api/services/cra.py
+++ b/django/api/services/cra.py
@@ -59,8 +59,8 @@ def write(
     # Write the body
     for row in data:
         sin = row["sin"]
-        family_name = row["family_name"].ljust(30)
-        given_name = row["given_name"].ljust(30)
+        family_name = row["family_name"].ljust(30)[:30]
+        given_name = row["given_name"].ljust(30)[:30]
         tax_years = " ".join([str(year) for year in row["years"]]).ljust(20)
         birth_date = row["birth_date"]
         identifier = row["application_id"].ljust(30)

--- a/django/api/services/tests/cra_in_out/in/TO.ATO#@@00.R7005.IN.BCVR.A00009
+++ b/django/api/services/tests/cra_in_out/in/TO.ATO#@@00.R7005.IN.BCVR.A00009
@@ -1,0 +1,5 @@
+7100                        20220516 BCVRA00009                                                                                                   0
+7101270300379    0020SolangeSolangeSolangeSolangeSoAliceAliceAliceAliceAliceAlice197101222020                BCVR1234                             0
+7101302435839    0020Turner                        Wendy                         197805212020                BCVR1234                             0
+7101129922258    0020Redding                       Lily                          198307072020                BCVR1234                             0
+7102                        20220516 BCVRA00009      00000005                                                                                     0

--- a/django/api/services/tests/test_cra_write.py
+++ b/django/api/services/tests/test_cra_write.py
@@ -111,3 +111,53 @@ class TestCraWrite(SimpleTestCase):
 
             # Check file contents are exactly equal.
             self.assertEqual(file_contents, file)
+
+    # Test against cra in file 00009
+    def test_write_in_00009(self):
+        data = [
+            {
+                "sin": "270300379",
+                "years": [2020],
+                "given_name": "AliceAliceAliceAliceAliceAliceTruncateMe",
+                "family_name": "SolangeSolangeSolangeSolangeSolange",
+                "birth_date": "19710122",
+                "application_id": "1234",
+            },
+            {
+                "sin": "302435839",
+                "years": [2020],
+                "given_name": "Wendy",
+                "family_name": "Turner",
+                "birth_date": "19780521",
+                "application_id": "1234",
+            },
+            {
+                "sin": "129922258",
+                "years": [2020],
+                "given_name": "Lily",
+                "family_name": "Redding",
+                "birth_date": "19830707",
+                "application_id": "1234",
+            },
+        ]
+
+        file_contents = cra.write(
+            data,
+            today="20220516",
+            program_code="BCVR",
+            cra_env="A",
+            cra_sequence="00009",
+        )
+
+        cra_in_file_00009_filename = os.path.join(
+            os.path.dirname(__file__),
+            "cra_in_out",
+            "in",
+            "TO.ATO#@@00.R7005.IN.BCVR.A00009",
+        )
+
+        with open(cra_in_file_00009_filename, "r") as cra_in_file_00009:
+            file = cra_in_file_00009.read()
+
+            # Check file contents are exactly equal.
+            self.assertEqual(file_contents, file)


### PR DESCRIPTION
Protect against really long first and last names sent to the cra.

They only match against the beginning of the name past a certain length anyways says the guide.