### PR TITLE
itvr-362--schedule-ncda-job

### DIFF
--- a/django/api/apps.py
+++ b/django/api/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 from django.contrib.admin.apps import AdminConfig
+from . import settings
+import sys
 
 
 class ApiConfig(AppConfig):
@@ -8,6 +10,10 @@ class ApiConfig(AppConfig):
 
     def ready(self):
         import api.signals
+        from api.scheduled_jobs import schedule_get_ncda_redeemed_rebates
+
+        if settings.RUN_JOBS and "qcluster" in sys.argv:
+            schedule_get_ncda_redeemed_rebates()
 
 
 class ITVRAdminConfig(AdminConfig):

--- a/django/api/scheduled_jobs.py
+++ b/django/api/scheduled_jobs.py
@@ -1,0 +1,12 @@
+from django_q.tasks import schedule
+from django_q.models import Schedule
+
+
+def schedule_exists(func_name):
+    return Schedule.objects.filter(func__exact=func_name).exists()
+
+
+def schedule_get_ncda_redeemed_rebates():
+    task_name = "api.tasks.check_rebates_redeemed_since"
+    if not schedule_exists(task_name):
+        schedule(task_name, None, task_name, schedule_type="D")

--- a/django/api/settings.py
+++ b/django/api/settings.py
@@ -251,3 +251,5 @@ NCDA_SHAREPOINT_URL = os.getenv(
 )
 
 MESSAGE_TAGS = messages_custom.TAGS
+
+RUN_JOBS = os.getenv("RUN_JOBS", False)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - CHES_EMAIL_URL
       - SEND_EMAIL
       - NCDA_CLIENT_SECRET
+      - RUN_JOBS=TRUE
     volumes:
       - ./django:/api
     depends_on:


### PR DESCRIPTION
Some remarks:

(1) See the django_q documentation on missed schedules (https://django-q.readthedocs.io/en/latest/schedules.html). We'll just use the default behaviour described there.

(2) The time we pass to the get_rebates_redeemed_since() function is derived from the next_run time of the schedule; this, combined with django_q's default config for missed schedules should ensure that no redeemed rebates get missed, even if the server goes down for some period of time.