### PR TITLE
itvr-337--spouse-login-validation

### DIFF
--- a/django/api/viewsets/application_form.py
+++ b/django/api/viewsets/application_form.py
@@ -18,10 +18,12 @@ class ApplicationFormViewset(GenericViewSet, CreateModelMixin, RetrieveModelMixi
 
     @action(detail=True, methods=["GET"], url_path="household")
     def household(self, request, pk=None):
-        # not possible to restrict this endpoint to only the spouse because, at this point,
-        # no household_member record associated with the spouse has been created yet, and we're not storing the spouse email
-        # associated with household applications
         application = GoElectricRebateApplication.objects.get(pk=pk)
+        application_user_id = application.user.id
+        household_user_id = request.user.id
+        if application_user_id == household_user_id:
+            error = {"error": "same_user"}
+            return Response(error, status=status.HTTP_401_UNAUTHORIZED)
         serializer = ApplicationFormSpouseSerializer(application)
         return Response(serializer.data)
 

--- a/frontend/src/components/HouseholdLoginError.js
+++ b/frontend/src/components/HouseholdLoginError.js
@@ -1,0 +1,39 @@
+import { useKeycloak } from '@react-keycloak/web';
+import Box from '@mui/material/Box';
+
+const HouseholdLoginError = ({ id }) => {
+  const { keycloak } = useKeycloak();
+  if (keycloak.authenticated) {
+    return (
+      <Box>
+        <h2>Log in error</h2>
+        <p>
+          You must use your own BC Services Card app or Basic BCeID account to
+          log in.
+        </p>
+        <p>
+          You cannot use the same log in credentials as the applicant to
+          complete your household rebate application.
+        </p>
+        <p>
+          Click the Log out button and log in using your own BC Services Card
+          app or Basic BCeID account.
+        </p>
+        <button
+          type="button"
+          className="button"
+          onClick={() => {
+            keycloak.logout({
+              redirectUri: `${window.location.origin}/household?q=${id}`
+            });
+          }}
+        >
+          Log out
+        </button>
+      </Box>
+    );
+  }
+  return null;
+};
+
+export default HouseholdLoginError;

--- a/frontend/src/components/Layout.js
+++ b/frontend/src/components/Layout.js
@@ -4,11 +4,11 @@ import Footer from './Footer';
 
 const Layout = ({ children }) => {
   return (
-    <>
+    <div className="layout">
       <Header />
       <main className="page-content">{children}</main>
       <Footer />
-    </>
+    </div>
   );
 };
 export default Layout;

--- a/frontend/src/components/SpouseForm.js
+++ b/frontend/src/components/SpouseForm.js
@@ -21,6 +21,7 @@ import { addTokenFields } from '../keycloak';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import HouseholdLoginError from './HouseholdLoginError';
 
 export const defaultValues = {
   application: '',
@@ -62,10 +63,22 @@ const SpouseForm = ({ id, setNumberOfErrors, setErrorsExistCounter }) => {
       .get(`/api/application-form/${id}/household`)
       .then((response) => response.data);
 
-  const { data, isLoading, isError, error } = useQuery(
-    ['spouse-application', id],
-    queryFn
-  );
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['spouse-application', id],
+    queryFn: queryFn,
+    retry: (failureCount, error) => {
+      const errorResponse = error.response;
+      if (
+        errorResponse &&
+        errorResponse.data &&
+        errorResponse.data.error === 'same_user'
+      ) {
+        return false;
+      } else if (failureCount >= 2) {
+        return false;
+      }
+    }
+  });
 
   const navigate = useNavigate();
   const mutation = useMutation((data) => {
@@ -121,6 +134,14 @@ const SpouseForm = ({ id, setNumberOfErrors, setErrorsExistCounter }) => {
     return <p>Loading...</p>;
   }
   if (isError) {
+    const errorResponse = error.response;
+    if (
+      errorResponse &&
+      errorResponse.data &&
+      errorResponse.data.error === 'same_user'
+    ) {
+      return <HouseholdLoginError id={id} />;
+    }
     return <p>{error.message}</p>;
   }
   const { address, city, postal_code: postalCode } = data;

--- a/frontend/src/components/SpouseForm.js
+++ b/frontend/src/components/SpouseForm.js
@@ -77,6 +77,7 @@ const SpouseForm = ({ id, setNumberOfErrors, setErrorsExistCounter }) => {
       } else if (failureCount >= 2) {
         return false;
       }
+      return true;
     }
   });
 

--- a/frontend/src/styles/App.scss
+++ b/frontend/src/styles/App.scss
@@ -30,3 +30,8 @@ ie General Container
     padding: 0 1rem;
   }
 }
+
+.layout {
+  position: relative;
+  min-height: 100vh;
+}

--- a/frontend/src/styles/Footer.scss
+++ b/frontend/src/styles/Footer.scss
@@ -1,4 +1,7 @@
 footer {
+  position: absolute;
+  width: 100%;
+  bottom: 0;
   background-color: #036;
   border-top: 2px solid #fcba19;
   color: #fff;

--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -131,7 +131,7 @@ a {
 
 .page-content {
   margin: 0 6rem 0 6rem;
-  padding-bottom: 2rem;
+  padding-bottom: 6rem;
 }
 
 span.validated {


### PR DESCRIPTION
Remarks:

(1) Frontend initiated validation for when a spouse logs in. No database constraints - doing so requires a cross-table constraint, which is not possible given our current models (see https://forum.djangoproject.com/t/checkconstraint-involving-related-model/5351). We can create a new "application_user_id" field in household_member and use that for a constraint (application_user_id != user_id), but I'm not sure if this violates db best practices. There are also other constraints that aren't there because of the same reason (e.g. in the application model: user is not bcsc => doc1 and doc2 cannot be null, etc.). Should probably take a look at these later...