### PR TITLE
itvr-365--cancel-from-login-page--backend

### DIFF
--- a/django/api/authentication/keycloak.py
+++ b/django/api/authentication/keycloak.py
@@ -69,9 +69,9 @@ class KeycloakAuthentication(TokenAuthentication):
             user, created = ITVRUser.objects.get_or_create(
                 username=token_info.get("sub"),
                 defaults={
-                    "display_name": token_info.get("display_name"),
+                    "display_name": token_info.get("display_name", ""),
                     "email": token_info.get("email", ""),
-                    "identity_provider": token_info.get("identity_provider"),
+                    "identity_provider": token_info.get("identity_provider", ""),
                 },
             )
 

--- a/django/api/urls.py
+++ b/django/api/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework import routers
-
+from api.viewsets.application_form_open import OpenApplicationFormViewset
 from api.viewsets.application_form import ApplicationFormViewset
 from api.viewsets.household_member import HouseholdMemberApplicationViewset
 
@@ -13,6 +13,8 @@ class OptionalSlashRouter(routers.DefaultRouter):
 
 
 ROUTER = OptionalSlashRouter()
+# uncomment the line below to expose the unrestricted endpoints in OpenApplicationFormViewset
+# ROUTER.register(r"open-application-form", OpenApplicationFormViewset)
 ROUTER.register(r"application-form", ApplicationFormViewset)
 ROUTER.register(r"spouse-application", HouseholdMemberApplicationViewset)
 

--- a/django/api/viewsets/application_form_open.py
+++ b/django/api/viewsets/application_form_open.py
@@ -1,0 +1,39 @@
+from rest_framework.viewsets import GenericViewSet
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.mixins import UpdateModelMixin
+from api.models.go_electric_rebate_application import GoElectricRebateApplication
+
+
+# unrestricted viewset
+class OpenApplicationFormViewset(GenericViewSet, UpdateModelMixin):
+    queryset = GoElectricRebateApplication.objects.all()
+    authentication_classes = []
+    permission_classes = []
+
+    @action(detail=True, methods=["GET"], url_path="cancellable")
+    def get_cancellable(self, request, pk=None):
+        cancellable = (
+            GoElectricRebateApplication.objects.filter(pk=pk)
+            .filter(status=GoElectricRebateApplication.Status.HOUSEHOLD_INITIATED)
+            .exists()
+        )
+        if cancellable:
+            return Response({"cancellable": True})
+        return Response({"cancellable": False})
+
+    def update(self, request, pk=None):
+        return Response(status=status.HTTP_403_FORBIDDEN)
+
+    # currently only used for cancelling household_initiated applications; consider using a serializer if the logic becomes more complicated
+    def partial_update(self, request, pk=None):
+        if request.data.get("status") == GoElectricRebateApplication.Status.CANCELLED:
+            application = GoElectricRebateApplication.objects.get(pk=pk)
+            if (
+                application.status
+                == GoElectricRebateApplication.Status.HOUSEHOLD_INITIATED
+            ):
+                application.status = GoElectricRebateApplication.Status.CANCELLED
+                application.save(update_fields=["status"])
+                return Response(status=status.HTTP_200_OK)

--- a/frontend/src/components/SpouseForm.js
+++ b/frontend/src/components/SpouseForm.js
@@ -85,7 +85,8 @@ const SpouseForm = ({ id, setNumberOfErrors, setErrorsExistCounter }) => {
         return false;
       }
       return true;
-    }
+    },
+    refetchOnWindowFocus: false
   });
 
   const navigate = useNavigate();
@@ -141,7 +142,7 @@ const SpouseForm = ({ id, setNumberOfErrors, setErrorsExistCounter }) => {
   const cancelApplication = () => {
     setLoading(true);
     axiosInstance.current
-      .get(`/api/application-form/${id}/cancel`)
+      .patch(`/api/application-form/${id}`, { status: 'cancelled' })
       .then((response) => {
         setApplicationCancelled(true);
         setLoading(false);


### PR DESCRIPTION
(1) Implemented an unrestricted viewset with endpoints that can be called to determine if an application is cancellable, or to cancel an application. Currently disabled, but can be enabled by uncommenting out a line in urls.py.

(2) If we do decide to move forward with this, we just need to enable the viewset, and implement the frontend.