### PR TITLE
fix: itvr-459 - remove argument passed to cra automation tasks

### DIFF
--- a/django/api/scheduled_jobs.py
+++ b/django/api/scheduled_jobs.py
@@ -54,6 +54,7 @@ def schedule_expire_expired_applications():
     except IntegrityError:
         pass
 
+
 def schedule_upload_verified_applications_last_24hours_to_s3():
     try:
         schedule(
@@ -61,10 +62,10 @@ def schedule_upload_verified_applications_last_24hours_to_s3():
             name="upload_verified_applications_last_24hours_to_s3",
             schedule_type="C",
             cron="00 22 * * *",
-            include_scheduled_run_day_minus_one=True,
         )
     except IntegrityError:
         pass
+
 
 def schedule_update_applications_cra_response():
     try:
@@ -73,7 +74,6 @@ def schedule_update_applications_cra_response():
             name="update_applications_cra_response",
             schedule_type="C",
             cron="00 21 * * *",
-            include_scheduled_run_day_minus_one=True,
         )
     except IntegrityError:
         pass


### PR DESCRIPTION
I noticed in the test console that the new cra jobs were failing; the error was: update_applications_cra_response() takes 0 positional arguments but 1 was given. This is because in the job definition, we have include_scheduled_run_day_minus_one=True, which passes an argument to the function that the job calls. I removed this configuration.